### PR TITLE
use _uncached_http_get instead of long_poll when get new namespace's config

### DIFF
--- a/pyapollo/apollo_client.py
+++ b/pyapollo/apollo_client.py
@@ -84,8 +84,8 @@ class ApolloClient(object):
         if namespace not in self._cache:
             self._cache[namespace] = {}
             logging.getLogger(__name__).info("Add namespace '%s' to local cache", namespace)
-            # This is a new namespace, need to do a blocking fetch to populate the local cache
-            self._long_poll()
+            # This is a new namespace, need to get config from config server without cache
+            self._uncached_http_get(namespace=namespace)
 
         if key in self._cache[namespace]:
             return self._cache[namespace][key]


### PR DESCRIPTION
第一次拿配置的时候，如果用long_poll会阻塞60秒，对一些web类型业务，在启动的时候是不太能接受的。改成用 `_uncached_http_get` 拿可以避免这个问题。